### PR TITLE
prevent leading zero being stripped off in CI

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-slurm_exporter_version: "0.8"
+slurm_exporter_version: "{{ '0.8' }}"
 slurm_exporter_web_listen_address: "0.0.0.0:8080"
 
 slurm_exporter_system_group: "slurm-exp"


### PR DESCRIPTION
Prevent 0.8 being auto converted to a float. This is printed without the leading zero.